### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Stories in Ready](https://badge.waffle.io/lazyengineering/faststatus.png?label=ready&title=Ready)](https://waffle.io/lazyengineering/faststatus)
 # faststatus
 Simple API for sharing if a resource is free, busy, or very busy


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/lazyengineering/faststatus

This was requested by a real person (user jessecarl) on waffle.io, we're not trying to spam you.