### PR TITLE
Cleanup/vet and lint

### DIFF
--- a/id.go
+++ b/id.go
@@ -9,11 +9,11 @@ import (
 	"fmt"
 )
 
-// A UUIDv4 compatible byte array. Implementation is based on
+// ID is a UUIDv4 compatible byte array. Implementation is based on
 // portions of github.com/satori/go.uuid.
 type ID [16]byte
 
-// Generate a new version 4 UUID. Returns errors from reading the
+// NewID generates a new version 4 UUID. Returns errors from reading the
 // entropy source.
 func NewID() (ID, error) {
 	id := ID{}

--- a/resource.go
+++ b/resource.go
@@ -118,7 +118,7 @@ func (r Resource) MarshalJSON() ([]byte, error) {
 	return json.Marshal(tmpResource)
 }
 
-// UnmarshalJson will populate a Resource with data from a json struct
+// UnmarshalJSON will populate a Resource with data from a json struct
 // according to the same format as MarshalJSON. Will overwrite any values
 // already assigned to the Resource.
 func (r *Resource) UnmarshalJSON(raw []byte) error {

--- a/resource_test.go
+++ b/resource_test.go
@@ -681,7 +681,7 @@ func TestResourceMarshalUnmarshalJSON(t *testing.T) {
 				t.Fatalf("json.Unmarshal(json.Marshal(%+v)) = %+v, expected error? %+v", tc.resource, err, tc.wantError)
 			}
 			if !reflect.DeepEqual(actual, tc.wantResource) {
-				t.Fatalf("json.Unmarshal(json.Marshal(%+v)) = <error>, expected %+v", tc.resource, actual, tc.wantResource)
+				t.Fatalf("json.Unmarshal(json.Marshal(%+v)) = <error>, got %+v, expected %+v", tc.resource, actual, tc.wantResource)
 			}
 		})
 	}

--- a/status.go
+++ b/status.go
@@ -16,10 +16,11 @@ import (
 // of applications.
 type Status uint8
 
+// The following predefined Status values are the only valid status values
 const (
-	Free     Status = iota // completely free resource
-	Busy                   // resource is busy
-	Occupied               // resource completely busy
+	Free     Status = iota // a completely unutilized resource
+	Busy                   // a resource that is being utilized, but not to capacity
+	Occupied               // a resource that is being utilized to capacity
 )
 const statusText = "freebusyoccupied"
 const statusNumbers = "012"

--- a/status_test.go
+++ b/status_test.go
@@ -245,22 +245,22 @@ func TestStatusString(t *testing.T) {
 		Status   Status
 	}
 	tests := []stringTest{
-		stringTest{ // Zero Value
+		{ // Zero Value
 			Expected: "free",
 		},
-		stringTest{ // Free
+		{ // Free
 			Expected: "free",
 			Status:   Free,
 		},
-		stringTest{ // Busy
+		{ // Busy
 			Expected: "busy",
 			Status:   Busy,
 		},
-		stringTest{ // Occupied
+		{ // Occupied
 			Expected: "occupied",
 			Status:   Occupied,
 		},
-		stringTest{ // Out of Range
+		{ // Out of Range
 			Expected: "free",
 			Status:   Occupied + 1,
 		},

--- a/store/store.go
+++ b/store/store.go
@@ -64,6 +64,8 @@ func (s *Store) Save(r faststatus.Resource) error {
 	return nil
 }
 
+// Get returns the most recent state of the Resource with the given valid ID
+// or a zero-value Resource if it does not exist in the Store.
 func (s *Store) Get(id faststatus.ID) (faststatus.Resource, error) {
 	if s == nil {
 		return faststatus.Resource{}, errorStoreNotInitialized

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -155,7 +155,7 @@ func TestSaveIsConcurrencySafe(t *testing.T) {
 	s := &store.Store{DB: db}
 
 	testResources := []faststatus.Resource{
-		faststatus.Resource{
+		{
 			ID:     faststatus.ID{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef},
 			Status: faststatus.Busy,
 			Since: func() time.Time {
@@ -164,7 +164,7 @@ func TestSaveIsConcurrencySafe(t *testing.T) {
 			}(),
 			FriendlyName: "First One",
 		},
-		faststatus.Resource{
+		{
 			ID:     faststatus.ID{0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01},
 			Status: faststatus.Free,
 			Since: func() time.Time {
@@ -173,7 +173,7 @@ func TestSaveIsConcurrencySafe(t *testing.T) {
 			}(),
 			FriendlyName: "Second One",
 		},
-		faststatus.Resource{
+		{
 			ID:     faststatus.ID{0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23},
 			Status: faststatus.Occupied,
 			Since: func() time.Time {
@@ -182,7 +182,7 @@ func TestSaveIsConcurrencySafe(t *testing.T) {
 			}(),
 			FriendlyName: "Third One",
 		},
-		faststatus.Resource{
+		{
 			ID: faststatus.ID{
 				0x67,
 				0x89,
@@ -208,7 +208,7 @@ func TestSaveIsConcurrencySafe(t *testing.T) {
 			}(),
 			FriendlyName: "First One",
 		},
-		faststatus.Resource{
+		{
 			ID: faststatus.ID{
 				0x89,
 				0xab,
@@ -263,7 +263,7 @@ func TestSaveStoresOnlyLatest(t *testing.T) {
 	s := &store.Store{DB: db}
 
 	testResources := map[string]faststatus.Resource{
-		"first": faststatus.Resource{
+		"first": {
 			ID:     faststatus.ID{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef},
 			Status: faststatus.Free,
 			Since: func() time.Time {
@@ -272,7 +272,7 @@ func TestSaveStoresOnlyLatest(t *testing.T) {
 			}(),
 			FriendlyName: "First One",
 		},
-		"second": faststatus.Resource{
+		"second": {
 			ID:     faststatus.ID{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef},
 			Status: faststatus.Busy,
 			Since: func() time.Time {
@@ -281,7 +281,7 @@ func TestSaveStoresOnlyLatest(t *testing.T) {
 			}(),
 			FriendlyName: "Second One",
 		},
-		"third": faststatus.Resource{
+		"third": {
 			ID:     faststatus.ID{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef},
 			Status: faststatus.Occupied,
 			Since: func() time.Time {
@@ -290,7 +290,7 @@ func TestSaveStoresOnlyLatest(t *testing.T) {
 			}(),
 			FriendlyName: "Third One",
 		},
-		"fourth": faststatus.Resource{
+		"fourth": {
 			ID:     faststatus.ID{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef},
 			Status: faststatus.Free,
 			Since: func() time.Time {
@@ -299,7 +299,7 @@ func TestSaveStoresOnlyLatest(t *testing.T) {
 			}(),
 			FriendlyName: "Fourth One",
 		},
-		"final": faststatus.Resource{
+		"final": {
 			ID:     faststatus.ID{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef},
 			Status: faststatus.Busy,
 			Since: func() time.Time {
@@ -337,7 +337,7 @@ func TestGet(t *testing.T) {
 	defer cleanup()
 
 	stockResources := map[string]faststatus.Resource{
-		"valid": faststatus.Resource{
+		"valid": {
 			ID:     faststatus.ID{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef},
 			Status: faststatus.Busy,
 			Since: func() time.Time {
@@ -346,7 +346,7 @@ func TestGet(t *testing.T) {
 			}(),
 			FriendlyName: "First One",
 		},
-		"not-found": faststatus.Resource{
+		"not-found": {
 			ID:     faststatus.ID{0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01},
 			Status: faststatus.Busy,
 			Since: func() time.Time {
@@ -420,7 +420,7 @@ func TestGetIsConcurrencySafe(t *testing.T) {
 	s := &store.Store{DB: db}
 
 	testResources := []faststatus.Resource{
-		faststatus.Resource{
+		{
 			ID:     faststatus.ID{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef},
 			Status: faststatus.Busy,
 			Since: func() time.Time {
@@ -429,7 +429,7 @@ func TestGetIsConcurrencySafe(t *testing.T) {
 			}(),
 			FriendlyName: "First One",
 		},
-		faststatus.Resource{
+		{
 			ID:     faststatus.ID{0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01},
 			Status: faststatus.Free,
 			Since: func() time.Time {
@@ -438,7 +438,7 @@ func TestGetIsConcurrencySafe(t *testing.T) {
 			}(),
 			FriendlyName: "Second One",
 		},
-		faststatus.Resource{
+		{
 			ID:     faststatus.ID{0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23},
 			Status: faststatus.Occupied,
 			Since: func() time.Time {
@@ -447,7 +447,7 @@ func TestGetIsConcurrencySafe(t *testing.T) {
 			}(),
 			FriendlyName: "Third One",
 		},
-		faststatus.Resource{
+		{
 			ID:     faststatus.ID{0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45},
 			Status: faststatus.Busy,
 			Since: func() time.Time {
@@ -456,7 +456,7 @@ func TestGetIsConcurrencySafe(t *testing.T) {
 			}(),
 			FriendlyName: "First One",
 		},
-		faststatus.Resource{
+		{
 			ID:     faststatus.ID{0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67},
 			Status: faststatus.Free,
 			Since: func() time.Time {


### PR DESCRIPTION
Cleaned up to match vet expectations, lint expectations, and performed `gofmt -s` to simplify the code.

Closes Issue #20.