### PR TITLE
Bugfix/issue 13

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -107,6 +107,9 @@ func (r *Resource) UnmarshalText(txt []byte) error {
 	if err := (&tmp.Since).UnmarshalText(elements[2]); err != nil {
 		return fmt.Errorf("parsing Since from text: %+v", err)
 	}
+	if tmp.Since.IsZero() {
+		tmp.Since = time.Time{}
+	}
 
 	tmp.FriendlyName = string(bytes.Join(elements[3:], []byte(" ")))
 

--- a/resource_test.go
+++ b/resource_test.go
@@ -373,22 +373,7 @@ func TestResourceMarshalUnmarshalText(t *testing.T) {
 		if err != nil {
 			return false
 		}
-		switch {
-		case got.ID != r.ID:
-			t.Logf("ID got %+v, expected %+v", got.ID, r.ID)
-			return false
-		case got.Status != r.Status:
-			t.Logf("Status got %+v, expected %+v", got.Status, r.Status)
-			return false
-		case !got.Since.Equal(r.Since):
-			t.Logf("Since got %+v, expectected %+v", got.Since, r.Since)
-			return false
-		case got.FriendlyName != r.FriendlyName:
-			t.Logf("FriendlyName got %+v, expected %+v", got.FriendlyName, r.FriendlyName)
-			return false
-		default:
-			return true
-		}
+		return got.Equal(r)
 	}
 	if err := quick.Check(f, nil); err != nil {
 		t.Error(err)
@@ -641,22 +626,7 @@ func TestResourceMarshalUnmarshalJSON(t *testing.T) {
 		if err != nil {
 			return false
 		}
-		switch {
-		case got.ID != r.ID:
-			t.Logf("ID got %+v, expected %+v", got.ID, r.ID)
-			return false
-		case got.Status != r.Status:
-			t.Logf("Status got %+v, expected %+v", got.Status, r.Status)
-			return false
-		case !got.Since.Equal(r.Since):
-			t.Logf("Since got %+v, expectected %+v", got.Since, r.Since)
-			return false
-		case got.FriendlyName != r.FriendlyName:
-			t.Logf("FriendlyName got %+v, expected %+v", got.FriendlyName, r.FriendlyName)
-			return false
-		default:
-			return true
-		}
+		return got.Equal(r)
 	}
 	if err := quick.Check(f, nil); err != nil {
 		t.Error(err)

--- a/resource_test.go
+++ b/resource_test.go
@@ -11,26 +11,65 @@ import (
 	"testing"
 	"testing/quick"
 	"time"
+	"unicode/utf8"
 )
 
+var availableLocations []*time.Location
+
+func init() {
+	availableLocations = []*time.Location{
+		mustLocation(time.LoadLocation("Europe/London")),
+		mustLocation(time.LoadLocation("America/New_York")),
+		mustLocation(time.LoadLocation("America/Los_Angeles")),
+		mustLocation(time.LoadLocation("Australia/Sydney")),
+		mustLocation(time.LoadLocation("Asia/Tokyo")),
+		mustLocation(time.LoadLocation("Asia/Shanghai")),
+		mustLocation(time.LoadLocation("Asia/Kolkata")),
+		mustLocation(time.LoadLocation("Europe/Istanbul")),
+		mustLocation(time.LoadLocation("Europe/Zurich")),
+		time.UTC,
+	}
+}
+
+func mustLocation(loc *time.Location, err error) *time.Location {
+	if err != nil {
+		panic(err)
+	}
+	return loc
+}
+
 // Generate is used in testing to generate random valid Resource values
-func (r Resource) Generate(rand *rand.Rand, size int) reflect.Value {
+func (r Resource) Generate(rgen *rand.Rand, size int) reflect.Value {
 	rr := Resource{}
 
 	rr.ID, _ = NewID()
-	buf := make([]byte, rand.Intn(100))
-	rand.Read(buf)
-	rr.FriendlyName = string(buf)
-	rr.Status = Status(rand.Int() % int(Occupied))
+	rr.FriendlyName = func(rgen *rand.Rand, size int) string {
+		txt := make([]byte, 0, size)
+		for len(txt) < size {
+			p := make([]byte, 1)
+			n, err := rgen.Read(p)
+			if err != nil {
+				panic(err)
+			}
+			if n != 1 {
+				continue
+			}
+			if utf8.Valid(p) {
+				txt = append(txt, p...)
+			}
+		}
+		return string(txt)
+	}(rgen, rgen.Intn(100))
+	rr.Status = Status(rgen.Int() % int(Occupied))
 	rr.Since = time.Date(
-		2016+rand.Intn(10),
-		time.Month(rand.Intn(11)+1),
-		rand.Intn(27)+1,
-		rand.Intn(24),
-		rand.Intn(60),
-		rand.Intn(60),
+		2016+rgen.Intn(10),
+		time.Month(rgen.Intn(11)+1),
+		rgen.Intn(27)+1,
+		rgen.Intn(24),
+		rgen.Intn(60),
+		rgen.Intn(60),
 		0,
-		time.UTC,
+		availableLocations[rgen.Int()%len(availableLocations)],
 	)
 
 	return reflect.ValueOf(rr)
@@ -334,7 +373,22 @@ func TestResourceMarshalUnmarshalText(t *testing.T) {
 		if err != nil {
 			return false
 		}
-		return reflect.DeepEqual(*got, r)
+		switch {
+		case got.ID != r.ID:
+			t.Logf("ID got %+v, expected %+v", got.ID, r.ID)
+			return false
+		case got.Status != r.Status:
+			t.Logf("Status got %+v, expected %+v", got.Status, r.Status)
+			return false
+		case !got.Since.Equal(r.Since):
+			t.Logf("Since got %+v, expectected %+v", got.Since, r.Since)
+			return false
+		case got.FriendlyName != r.FriendlyName:
+			t.Logf("FriendlyName got %+v, expected %+v", got.FriendlyName, r.FriendlyName)
+			return false
+		default:
+			return true
+		}
 	}
 	if err := quick.Check(f, nil); err != nil {
 		t.Error(err)
@@ -577,113 +631,35 @@ func TestResourceUnmarshalJSON(t *testing.T) {
 }
 
 func TestResourceMarshalUnmarshalJSON(t *testing.T) {
-	testCases := []struct {
-		name         string
-		resource     Resource
-		wantResource Resource
-		wantError    bool
-	}{
-		{"Zero Value",
-			Resource{},
-			Resource{},
-			false,
-		},
-		{"Valid Busy",
-			Resource{
-				ID:           ID{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef},
-				FriendlyName: "First One",
-				Status:       Busy,
-				Since: func() time.Time {
-					tt, _ := time.Parse(time.RFC3339, "2016-05-12T16:25:00-07:00")
-					return tt
-				}(),
-			},
-			Resource{
-				ID:           ID{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef},
-				FriendlyName: "First One",
-				Status:       Busy,
-				Since: func() time.Time {
-					tt, _ := time.Parse(time.RFC3339, "2016-05-12T16:25:00-07:00")
-					return tt
-				}(),
-			},
-			false,
-		},
-		{"Valid Free",
-			Resource{
-				ID:           ID{0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01},
-				FriendlyName: "Second One",
-				Status:       Free,
-				Since: func() time.Time {
-					tt, _ := time.Parse(time.RFC3339, "2016-05-12T16:27:00-07:00")
-					return tt
-				}(),
-			},
-			Resource{
-				ID:           ID{0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01},
-				FriendlyName: "Second One",
-				Status:       Free,
-				Since: func() time.Time {
-					tt, _ := time.Parse(time.RFC3339, "2016-05-12T16:27:00-07:00")
-					return tt
-				}(),
-			},
-			false,
-		},
-		{"Valid Occupied",
-			Resource{
-				ID:           ID{0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23},
-				FriendlyName: "Third One",
-				Status:       Occupied,
-				Since: func() time.Time {
-					tt, _ := time.Parse(time.RFC3339, "2016-05-12T16:28:00-07:00")
-					return tt
-				}(),
-			},
-			Resource{
-				ID:           ID{0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23},
-				FriendlyName: "Third One",
-				Status:       Occupied,
-				Since: func() time.Time {
-					tt, _ := time.Parse(time.RFC3339, "2016-05-12T16:28:00-07:00")
-					return tt
-				}(),
-			},
-			false,
-		},
-		{"Out of Range",
-			Resource{
-				ID:           ID{0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45},
-				FriendlyName: "Another One",
-				Status:       Occupied + 1,
-				Since: func() time.Time {
-					tt, _ := time.Parse(time.RFC3339, "2016-05-12T16:30:00-07:00")
-					return tt
-				}(),
-			},
-			Resource{},
-			true,
-		},
+	f := func(r Resource) bool {
+		b, err := r.MarshalJSON()
+		if err != nil {
+			return false
+		}
+		got := new(Resource)
+		err = got.UnmarshalJSON(b)
+		if err != nil {
+			return false
+		}
+		switch {
+		case got.ID != r.ID:
+			t.Logf("ID got %+v, expected %+v", got.ID, r.ID)
+			return false
+		case got.Status != r.Status:
+			t.Logf("Status got %+v, expected %+v", got.Status, r.Status)
+			return false
+		case !got.Since.Equal(r.Since):
+			t.Logf("Since got %+v, expectected %+v", got.Since, r.Since)
+			return false
+		case got.FriendlyName != r.FriendlyName:
+			t.Logf("FriendlyName got %+v, expected %+v", got.FriendlyName, r.FriendlyName)
+			return false
+		default:
+			return true
+		}
 	}
-	for _, tc := range testCases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			actual, err := func(r Resource) (Resource, error) {
-				ac := new(Resource)
-				tmp, erx := json.Marshal(r)
-				if erx != nil {
-					return *ac, erx
-				}
-				erx = json.Unmarshal(tmp, ac)
-				return *ac, erx
-			}(tc.resource)
-			if (err != nil) != tc.wantError {
-				t.Fatalf("json.Unmarshal(json.Marshal(%+v)) = %+v, expected error? %+v", tc.resource, err, tc.wantError)
-			}
-			if !reflect.DeepEqual(actual, tc.wantResource) {
-				t.Fatalf("json.Unmarshal(json.Marshal(%+v)) = <error>, got %+v, expected %+v", tc.resource, actual, tc.wantResource)
-			}
-		})
+	if err := quick.Check(f, nil); err != nil {
+		t.Error(err)
 	}
 }
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -142,7 +142,7 @@ func TestSaveIsIdempotent(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error getting final resource: %+v", err)
 		}
-		if got != r {
+		if !got.Equal(r) {
 			t.Fatalf("getting resource for the %d time: got %+v, expected %+v", i+1, got, r)
 		}
 	}
@@ -327,7 +327,7 @@ func TestSaveStoresOnlyLatest(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error getting final resource: %+v", err)
 	}
-	if got != testResources["final"] {
+	if !got.Equal(testResources["final"]) {
 		t.Fatalf("getting final resource: got %+v, expected %+v", got, testResources["final"])
 	}
 }
@@ -406,7 +406,7 @@ func TestGet(t *testing.T) {
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("%+v.Get(%+v) = <Resource> %+v, expected error? %+v", tc.store, tc.id, err, tc.wantErr)
 			}
-			if gotResource != tc.wantResource {
+			if !gotResource.Equal(tc.wantResource) {
 				t.Fatalf("%+v.Get(%+v) = %+v <error>, expected %+v", tc.store, tc.id, gotResource, tc.wantResource)
 			}
 		})
@@ -485,7 +485,7 @@ func TestGetIsConcurrencySafe(t *testing.T) {
 			if err != nil {
 				t.Fatalf("no errors expected for concurrency test: %+v", err)
 			}
-			if got != r {
+			if !got.Equal(r) {
 				t.Fatalf("getting test resource from store: got %+v, expected %+v", got, r)
 			}
 		}(r)
@@ -519,7 +519,7 @@ func TestGetIsIdempotent(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error getting final resource: %+v", err)
 		}
-		if got != r {
+		if !got.Equal(r) {
 			t.Fatalf("getting resource for the %d time: got %+v, expected %+v", i+1, got, r)
 		}
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -34,7 +34,7 @@ func TestSave(t *testing.T) {
 				Status: faststatus.Busy,
 				Since: func() time.Time {
 					tt, _ := time.Parse(time.RFC3339, "2016-05-12T15:09:00-07:00")
-					return tt.UTC()
+					return tt
 				}(),
 				FriendlyName: "First One",
 			},
@@ -47,7 +47,7 @@ func TestSave(t *testing.T) {
 				Status: faststatus.Busy,
 				Since: func() time.Time {
 					tt, _ := time.Parse(time.RFC3339, "2016-05-12T15:09:00-07:00")
-					return tt.UTC()
+					return tt
 				}(),
 				FriendlyName: "First One",
 			},
@@ -60,7 +60,7 @@ func TestSave(t *testing.T) {
 				Status: faststatus.Busy,
 				Since: func() time.Time {
 					tt, _ := time.Parse(time.RFC3339, "2016-05-12T15:09:00-07:00")
-					return tt.UTC()
+					return tt
 				}(),
 				FriendlyName: "First One",
 			},
@@ -73,7 +73,7 @@ func TestSave(t *testing.T) {
 				Status: faststatus.Busy,
 				Since: func() time.Time {
 					tt, _ := time.Parse(time.RFC3339, "2016-05-12T15:09:00-07:00")
-					return tt.UTC()
+					return tt
 				}(),
 				FriendlyName: "First One",
 			},
@@ -86,7 +86,7 @@ func TestSave(t *testing.T) {
 				Status: faststatus.Busy,
 				Since: func() time.Time {
 					tt, _ := time.Parse(time.RFC3339, "2016-05-12T15:00:00-07:00")
-					return tt.UTC()
+					return tt
 				}(),
 				FriendlyName: "First One",
 			},
@@ -99,7 +99,7 @@ func TestSave(t *testing.T) {
 				Status: faststatus.Free,
 				Since: func() time.Time {
 					tt, _ := time.Parse(time.RFC3339, "2016-05-12T15:15:00-07:00")
-					return tt.UTC()
+					return tt
 				}(),
 				FriendlyName: "First One",
 			},
@@ -128,7 +128,7 @@ func TestSaveIsIdempotent(t *testing.T) {
 		Status: faststatus.Free,
 		Since: func() time.Time {
 			tt, _ := time.Parse(time.RFC3339, "2016-05-12T16:25:00-07:00")
-			return tt.UTC()
+			return tt
 		}(),
 		FriendlyName: "First One",
 	}
@@ -160,7 +160,7 @@ func TestSaveIsConcurrencySafe(t *testing.T) {
 			Status: faststatus.Busy,
 			Since: func() time.Time {
 				tt, _ := time.Parse(time.RFC3339, "2016-05-12T16:25:00-07:00")
-				return tt.UTC()
+				return tt
 			}(),
 			FriendlyName: "First One",
 		},
@@ -169,7 +169,7 @@ func TestSaveIsConcurrencySafe(t *testing.T) {
 			Status: faststatus.Free,
 			Since: func() time.Time {
 				tt, _ := time.Parse(time.RFC3339, "2016-05-12T16:27:00-07:00")
-				return tt.UTC()
+				return tt
 			}(),
 			FriendlyName: "Second One",
 		},
@@ -178,7 +178,7 @@ func TestSaveIsConcurrencySafe(t *testing.T) {
 			Status: faststatus.Occupied,
 			Since: func() time.Time {
 				tt, _ := time.Parse(time.RFC3339, "2016-05-12T16:28:00-07:00")
-				return tt.UTC()
+				return tt
 			}(),
 			FriendlyName: "Third One",
 		},
@@ -204,7 +204,7 @@ func TestSaveIsConcurrencySafe(t *testing.T) {
 			Status: faststatus.Busy,
 			Since: func() time.Time {
 				tt, _ := time.Parse(time.RFC3339, "2016-05-12T16:25:00-07:00")
-				return tt.UTC()
+				return tt
 			}(),
 			FriendlyName: "First One",
 		},
@@ -230,7 +230,7 @@ func TestSaveIsConcurrencySafe(t *testing.T) {
 			Status: faststatus.Free,
 			Since: func() time.Time {
 				tt, _ := time.Parse(time.RFC3339, "2016-05-12T16:25:01-07:00")
-				return tt.UTC()
+				return tt
 			}(),
 			FriendlyName: "Another One",
 		},
@@ -268,7 +268,7 @@ func TestSaveStoresOnlyLatest(t *testing.T) {
 			Status: faststatus.Free,
 			Since: func() time.Time {
 				tt, _ := time.Parse(time.RFC3339, "2016-05-12T16:25:00-07:00")
-				return tt.UTC()
+				return tt
 			}(),
 			FriendlyName: "First One",
 		},
@@ -277,7 +277,7 @@ func TestSaveStoresOnlyLatest(t *testing.T) {
 			Status: faststatus.Busy,
 			Since: func() time.Time {
 				tt, _ := time.Parse(time.RFC3339, "2016-05-12T16:25:01-07:00")
-				return tt.UTC()
+				return tt
 			}(),
 			FriendlyName: "Second One",
 		},
@@ -286,7 +286,7 @@ func TestSaveStoresOnlyLatest(t *testing.T) {
 			Status: faststatus.Occupied,
 			Since: func() time.Time {
 				tt, _ := time.Parse(time.RFC3339, "2016-05-12T16:25:02-07:00")
-				return tt.UTC()
+				return tt
 			}(),
 			FriendlyName: "Third One",
 		},
@@ -295,7 +295,7 @@ func TestSaveStoresOnlyLatest(t *testing.T) {
 			Status: faststatus.Free,
 			Since: func() time.Time {
 				tt, _ := time.Parse(time.RFC3339, "2016-05-12T16:25:03-07:00")
-				return tt.UTC()
+				return tt
 			}(),
 			FriendlyName: "Fourth One",
 		},
@@ -304,7 +304,7 @@ func TestSaveStoresOnlyLatest(t *testing.T) {
 			Status: faststatus.Busy,
 			Since: func() time.Time {
 				tt, _ := time.Parse(time.RFC3339, "2016-05-12T16:25:04-07:00")
-				return tt.UTC()
+				return tt
 			}(),
 			FriendlyName: "Last One",
 		},
@@ -342,7 +342,7 @@ func TestGet(t *testing.T) {
 			Status: faststatus.Busy,
 			Since: func() time.Time {
 				tt, _ := time.Parse(time.RFC3339, "2016-05-12T15:00:00-07:00")
-				return tt.UTC()
+				return tt
 			}(),
 			FriendlyName: "First One",
 		},
@@ -351,7 +351,7 @@ func TestGet(t *testing.T) {
 			Status: faststatus.Busy,
 			Since: func() time.Time {
 				tt, _ := time.Parse(time.RFC3339, "2016-05-12T15:00:00-07:00")
-				return tt.UTC()
+				return tt
 			}(),
 			FriendlyName: "First One",
 		},
@@ -425,7 +425,7 @@ func TestGetIsConcurrencySafe(t *testing.T) {
 			Status: faststatus.Busy,
 			Since: func() time.Time {
 				tt, _ := time.Parse(time.RFC3339, "2016-05-12T16:25:00-07:00")
-				return tt.UTC()
+				return tt
 			}(),
 			FriendlyName: "First One",
 		},
@@ -434,7 +434,7 @@ func TestGetIsConcurrencySafe(t *testing.T) {
 			Status: faststatus.Free,
 			Since: func() time.Time {
 				tt, _ := time.Parse(time.RFC3339, "2016-05-12T16:27:00-07:00")
-				return tt.UTC()
+				return tt
 			}(),
 			FriendlyName: "Second One",
 		},
@@ -443,7 +443,7 @@ func TestGetIsConcurrencySafe(t *testing.T) {
 			Status: faststatus.Occupied,
 			Since: func() time.Time {
 				tt, _ := time.Parse(time.RFC3339, "2016-05-12T16:28:00-07:00")
-				return tt.UTC()
+				return tt
 			}(),
 			FriendlyName: "Third One",
 		},
@@ -452,7 +452,7 @@ func TestGetIsConcurrencySafe(t *testing.T) {
 			Status: faststatus.Busy,
 			Since: func() time.Time {
 				tt, _ := time.Parse(time.RFC3339, "2016-05-12T16:25:00-07:00")
-				return tt.UTC()
+				return tt
 			}(),
 			FriendlyName: "First One",
 		},
@@ -461,7 +461,7 @@ func TestGetIsConcurrencySafe(t *testing.T) {
 			Status: faststatus.Free,
 			Since: func() time.Time {
 				tt, _ := time.Parse(time.RFC3339, "2016-05-12T16:25:01-07:00")
-				return tt.UTC()
+				return tt
 			}(),
 			FriendlyName: "Another One",
 		},
@@ -505,7 +505,7 @@ func TestGetIsIdempotent(t *testing.T) {
 		Status: faststatus.Free,
 		Since: func() time.Time {
 			tt, _ := time.Parse(time.RFC3339, "2016-05-12T16:25:00-07:00")
-			return tt.UTC()
+			return tt
 		}(),
 		FriendlyName: "First One",
 	}


### PR DESCRIPTION
Fix for issue #13 

Instead of making all resource time UTC (a difficult thing to enforce well), adds an equality method that uses the `time.Time.Equal()` method.