### PR TITLE
Cleanup/move tests

### DIFF
--- a/exports_test.go
+++ b/exports_test.go
@@ -1,0 +1,72 @@
+// Copyright 2016-2017 Jesse Allen. All rights reserved
+// Released under the MIT license found in the LICENSE file.
+
+package faststatus
+
+import (
+	"math/rand"
+	"reflect"
+	"time"
+	"unicode/utf8"
+)
+
+var availableLocations []*time.Location
+
+func init() {
+	availableLocations = []*time.Location{
+		mustLocation(time.LoadLocation("Europe/London")),
+		mustLocation(time.LoadLocation("America/New_York")),
+		mustLocation(time.LoadLocation("America/Los_Angeles")),
+		mustLocation(time.LoadLocation("Australia/Sydney")),
+		mustLocation(time.LoadLocation("Asia/Tokyo")),
+		mustLocation(time.LoadLocation("Asia/Shanghai")),
+		mustLocation(time.LoadLocation("Asia/Kolkata")),
+		mustLocation(time.LoadLocation("Europe/Istanbul")),
+		mustLocation(time.LoadLocation("Europe/Zurich")),
+		time.UTC,
+	}
+}
+
+func mustLocation(loc *time.Location, err error) *time.Location {
+	if err != nil {
+		panic(err)
+	}
+	return loc
+}
+
+// Generate is used in testing to generate random valid Resource values
+func (r Resource) Generate(rgen *rand.Rand, size int) reflect.Value {
+	rr := Resource{}
+
+	rr.ID, _ = NewID()
+	rr.FriendlyName = func(rgen *rand.Rand, size int) string {
+		txt := make([]byte, 0, size)
+		for len(txt) < size {
+			p := make([]byte, 1)
+			n, err := rgen.Read(p)
+			if err != nil {
+				panic(err)
+			}
+			if n != 1 {
+				continue
+			}
+			if utf8.Valid(p) {
+				txt = append(txt, p...)
+			}
+		}
+		return string(txt)
+	}(rgen, rgen.Intn(100))
+	rr.Status = Status(rgen.Int() % int(Occupied))
+	rr.Since = time.Date(
+		2016+rgen.Intn(10),
+		time.Month(rgen.Intn(11)+1),
+		rgen.Intn(27)+1,
+		rgen.Intn(24),
+		rgen.Intn(60),
+		rgen.Intn(60),
+		0,
+		availableLocations[rgen.Int()%len(availableLocations)],
+	)
+
+	return reflect.ValueOf(rr)
+}

--- a/exports_test.go
+++ b/exports_test.go
@@ -70,3 +70,8 @@ func (r Resource) Generate(rgen *rand.Rand, size int) reflect.Value {
 
 	return reflect.ValueOf(rr)
 }
+
+// Generate is used in testing to generate only valid Status values
+func (s Status) Generate(rand *rand.Rand, size int) reflect.Value {
+	return reflect.ValueOf(Status(rand.Int() % int(Occupied)))
+}

--- a/id_test.go
+++ b/id_test.go
@@ -90,7 +90,6 @@ func TestIDUnmarshalMarshalBinary(t *testing.T) {
 }
 
 func TestIDMarshalTextIs36Bytes(t *testing.T) {
-	// is 36 bytes
 	is36bytes := func(id faststatus.ID) bool {
 		s, err := id.MarshalText()
 		return err == nil && len(s) == 36
@@ -101,7 +100,6 @@ func TestIDMarshalTextIs36Bytes(t *testing.T) {
 }
 
 func TestIDMarshalTextIsValidChars(t *testing.T) {
-	// contains only lowercase hex and dashes
 	onlyHexAndDashes := func(id faststatus.ID) bool {
 		s, err := id.MarshalText()
 		if err != nil {
@@ -122,7 +120,6 @@ func TestIDMarshalTextIsValidChars(t *testing.T) {
 }
 
 func TestIDMarshalTextHasCorrectDashes(t *testing.T) {
-	// contains dashes where expected
 	dashesWhereExpected := func(id faststatus.ID) bool {
 		s, err := id.MarshalText()
 		if err != nil {

--- a/resource.go
+++ b/resource.go
@@ -86,7 +86,7 @@ func (r Resource) MarshalText() ([]byte, error) {
 
 // UnmarshalText decodes a Resource from a line of text. This matches the
 // output of the `MarshalText` method. Partial matches are only accepted missing
-// `FriendlyName` or `FriendlyName` and `Since`.
+// `FriendlyName`.
 func (r *Resource) UnmarshalText(txt []byte) error {
 	elements := bytes.Split(txt, []byte(" "))
 
@@ -140,12 +140,11 @@ func (r Resource) MarshalJSON() ([]byte, error) {
 // according to the same format as MarshalJSON. Will overwrite any values
 // already assigned to the Resource.
 func (r *Resource) UnmarshalJSON(raw []byte) error {
-	// allow zero values with omitempty
 	tmp := new(struct {
-		ID           ID        `json:",omitempty"`
-		Status       Status    `json:",omitempty"`
-		Since        time.Time `json:",omitempty"`
-		FriendlyName string    `json:",omitempty"`
+		ID           ID
+		Status       Status
+		Since        time.Time
+		FriendlyName string `json:",omitempty"`
 	})
 	if err := json.Unmarshal(raw, tmp); err != nil {
 		return err

--- a/resource_test.go
+++ b/resource_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/lazyengineering/faststatus"
 )
 
-// Expects [ID] [Status] [Since] [FriendlyName]
 func TestResourceString(t *testing.T) {
 	testCases := []struct {
 		name     string

--- a/status_test.go
+++ b/status_test.go
@@ -236,34 +236,37 @@ func TestStatusMarshalUnmarshalText(t *testing.T) {
 }
 
 func TestStatusString(t *testing.T) {
-	type stringTest struct {
-		Expected string
-		Status   faststatus.Status
+	testCases := []struct {
+		name     string
+		expected string
+		status   faststatus.Status
+	}{
+		{name: "Zero Value",
+			expected: "free",
+		},
+		{name: "Free",
+			expected: "free",
+			status:   faststatus.Free,
+		},
+		{name: "Busy",
+			expected: "busy",
+			status:   faststatus.Busy,
+		},
+		{name: "Occupied",
+			expected: "occupied",
+			status:   faststatus.Occupied,
+		},
+		{name: "Out of Range",
+			expected: "free",
+			status:   faststatus.Occupied + 1,
+		},
 	}
-	tests := []stringTest{
-		{ // Zero Value
-			Expected: "free",
-		},
-		{ // Free
-			Expected: "free",
-			Status:   faststatus.Free,
-		},
-		{ // Busy
-			Expected: "busy",
-			Status:   faststatus.Busy,
-		},
-		{ // Occupied
-			Expected: "occupied",
-			Status:   faststatus.Occupied,
-		},
-		{ // Out of Range
-			Expected: "free",
-			Status:   faststatus.Occupied + 1,
-		},
-	}
-	for _, st := range tests {
-		if actual := st.Status.String(); actual != st.Expected {
-			t.Error("\nexpected:\t", st.Expected, "\n  actual:\t", actual)
-		}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if actual := tc.status.String(); actual != tc.expected {
+				t.Fatalf("%#v.String() = %s, expected %s", tc.status, actual, tc.expected)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Moves all the tests to a `faststatus_test` package instead of the `faststatus` package. This completes issue #23 for the root package.