### PR TITLE
Add handler for Getting a new resource

### DIFF
--- a/rest/rest.go
+++ b/rest/rest.go
@@ -1,0 +1,40 @@
+// Copyright 2017 Jesse Allen. All rights reserved
+// Released under the MIT license found in the LICENSE file.
+
+package rest
+
+import (
+	"net/http"
+
+	"github.com/lazyengineering/faststatus"
+)
+
+type server struct{}
+
+// New provides a restful endpoint for managing faststatus Resources
+func New() http.Handler {
+	return &server{}
+}
+
+func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/new":
+		s.handleNew(w, r)
+	default:
+		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+	}
+}
+
+func (s *server) handleNew(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet, http.MethodHead:
+	default:
+		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+	}
+	resource := faststatus.NewResource()
+	txt, err := resource.MarshalText()
+	if err != nil {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+	}
+	w.Write(txt)
+}

--- a/rest/rest_test.go
+++ b/rest/rest_test.go
@@ -1,0 +1,179 @@
+// Copyright 2017 Jesse Allen. All rights reserved
+// Released under the MIT license found in the LICENSE file.
+
+package rest_test
+
+import (
+	"bytes"
+	"math/rand"
+	"mime"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"testing/quick"
+
+	"github.com/lazyengineering/faststatus"
+	"github.com/lazyengineering/faststatus/rest"
+)
+
+func TestHandlerOnlyValidPaths(t *testing.T) {
+	var s = rest.New()
+
+	isNotFound := func(method, path string) bool {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(method, path, nil)
+		s.ServeHTTP(w, r)
+
+		_, isValidPath := validMethodsByPath[path]
+		if !isValidPath && w.Code != http.StatusNotFound {
+			t.Logf("%s %q got %03d, expected 404", method, path, w.Code)
+			return false
+		}
+		if isValidPath && w.Code == http.StatusNotFound {
+			t.Logf("%s %q got %03d, expected not 404", method, path, w.Code)
+			return false
+		}
+		return true
+	}
+	if err := quick.Check(isNotFound, &quick.Config{
+		Values: func(args []reflect.Value, gen *rand.Rand) {
+			args[0] = reflect.ValueOf(possibleMethods[gen.Intn(len(possibleMethods))])
+			scratch := make([]byte, 1000)
+			gen.Read(scratch)
+			var path = "/" + strings.Map(func(char rune) rune {
+				switch {
+				case char >= '0' && char <= '9',
+					char >= 'A' && char <= 'Z',
+					char >= 'a' && char <= 'z',
+					char == '!',
+					char == '$',
+					char >= 0x27 && char <= '/':
+					return char
+				default:
+					return -1
+				}
+			}, string(scratch))
+			path = path[:25%len(path)]
+			args[1] = reflect.ValueOf(path)
+		},
+	}); err != nil {
+		t.Fatalf("unexpected response to bad client request: %+v", err)
+	}
+}
+
+func TestHandlerOnlyValidPathsAndMethods(t *testing.T) {
+	var s = rest.New()
+	isNotAllowed := func(path string) func(string) bool {
+		return func(method string) bool {
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(method, path, nil)
+			s.ServeHTTP(w, r)
+
+			validMethods := validMethodsByPath[path]
+			var isValid bool
+			for _, validMethod := range validMethods {
+				if validMethod == method {
+					isValid = true
+					break
+				}
+			}
+			if !isValid && w.Code != http.StatusMethodNotAllowed {
+				t.Logf("%s %q got %03d, expected 405", method, path, w.Code)
+				return false
+			}
+			if isValid && w.Code == http.StatusMethodNotAllowed {
+				t.Logf("%s %q got %03d, expected not 405", method, path, w.Code)
+				return false
+			}
+			return true
+		}
+	}
+	genMethod := func(args []reflect.Value, gen *rand.Rand) {
+		args[0] = reflect.ValueOf(possibleMethods[gen.Intn(len(possibleMethods))])
+	}
+	for path := range validMethodsByPath {
+		if err := quick.Check(isNotAllowed(path), &quick.Config{Values: genMethod}); err != nil {
+			t.Fatalf("unexpected response to bad client request: %+v", err)
+		}
+	}
+}
+
+var possibleMethods = []string{
+	http.MethodGet,
+	http.MethodHead,
+	http.MethodPut,
+	http.MethodPost,
+	http.MethodPatch,
+	http.MethodDelete,
+}
+var validMethodsByPath = map[string][]string{
+	"/new": []string{http.MethodGet, http.MethodHead},
+}
+
+func TestHandlerGetNew(t *testing.T) {
+	const defaultContentType = "text/plain"
+	var s = rest.New()
+	var mu sync.Mutex
+	var usedIDs = make(map[faststatus.ID]struct{})
+	getsNewResource := func() bool {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/new", nil)
+		s.ServeHTTP(w, r)
+
+		if w.Code != http.StatusOK {
+			t.Logf(
+				"returned Status Code %03d, expected %03d",
+				w.Code,
+				http.StatusOK,
+			)
+			return false
+		}
+
+		gotType, _, err := mime.ParseMediaType(w.HeaderMap.Get("Content-Type"))
+		if err != nil {
+			t.Logf("error parsing content type: %+v", err)
+			return false
+		}
+		if gotType != defaultContentType {
+			t.Logf("Content-Type %q, expected %q", gotType, defaultContentType)
+			return false
+		}
+
+		var (
+			gotResource  faststatus.Resource
+			zeroResource faststatus.Resource
+		)
+		err = (&gotResource).UnmarshalText(w.Body.Bytes())
+		if err != nil {
+			t.Logf("error unmarshaling Resource from text body: %+v", err)
+			return false
+		}
+
+		if bytes.Equal(gotResource.ID[:], zeroResource.ID[:]) {
+			t.Logf("ID should be non-zero")
+			return false
+		}
+
+		if _, exists := usedIDs[gotResource.ID]; exists {
+			t.Logf("ID should be unique")
+			return false
+		}
+		mu.Lock()
+		usedIDs[gotResource.ID] = struct{}{}
+		mu.Unlock()
+
+		gotResource.ID = zeroResource.ID
+		if !gotResource.Equal(zeroResource) {
+			t.Logf("with ID set to zero-value got %+v, expected %+v", gotResource, zeroResource)
+			return false
+		}
+
+		return true
+	}
+	if err := quick.Check(getsNewResource, nil); err != nil {
+		t.Fatalf("GET /new does not get a new Resource: %+v", err)
+	}
+}


### PR DESCRIPTION
In order to create new resources using only idempotent actions, a
handler for getting a unique new resource was implemented. The handler
will *always* return a resource with a unique ID and otherwise
zero-value properties.

Addresses Issue #5 